### PR TITLE
Feat : InputField 컴포넌트 생성

### DIFF
--- a/components/common/Input/index.tsx
+++ b/components/common/Input/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { getFontSize, getBorderClasses } from './styles';
 
-interface InputProps extends React.InputHTMLAttributes<HTMLInputElement> {
+export interface InputProps extends React.InputHTMLAttributes<HTMLInputElement> {
   isValid?: boolean;
   leftIcon?: React.ReactNode;
   rightIcon?: React.ReactNode;

--- a/components/compound/input/InputField.tsx
+++ b/components/compound/input/InputField.tsx
@@ -1,0 +1,43 @@
+import React from 'react';
+import Input, { InputProps } from '@/components/common/Input';
+import { getFontSize } from '@/components/common/Input/styles';
+interface InputFieldProps extends InputProps {
+  label: React.ReactNode;
+  required?: boolean;
+  isValid?: boolean;
+  errorMessage?: string;
+  errorMessageFontSize?: number;
+  customLabelClass?: string;
+}
+
+const InputField = ({
+  id,
+  label,
+  ref,
+  customLabelClass,
+  required,
+  isValid,
+  errorMessage,
+  errorMessageFontSize = 14,
+  ...inputProps
+}: InputFieldProps) => {
+  return (
+    <div className="flex flex-col gap-2">
+      <label
+        htmlFor={id}
+        className={`text-medium18 text-black200 flex items-center gap-[2px] ${customLabelClass}`}
+      >
+        {label}
+        {required && <span className="text-[var(--color-violet)]">*</span>}
+      </label>
+      <Input id={id} ref={ref} isValid={isValid} {...inputProps} />
+      {!isValid && (
+        <span className={`text-[var(--color-red)] ${getFontSize(errorMessageFontSize)}`}>
+          {errorMessage}
+        </span>
+      )}
+    </div>
+  );
+};
+
+export default InputField;


### PR DESCRIPTION
## #️⃣연관된 이슈, 작업


## 📝작업 내용

- InputField 컴포넌트 생성
- 필수 입력 필드의 별표(*) 표시를 보라색으로 강조

## 사용 예시

```tsx
<InputField
  type="email"
  id="email"
  label="이메일"
  placeholder="이메일을 입력해주세요."
  customLabelClass="스타일 지정"
  isValid={isEmailValid}
  errorMessage="올바른 이메일 형식이 아닙니다."
  errorMessageFontSize={16} // 기본 14
  required
/>
```

## 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> e.g. 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?