### PR TITLE
Refactor : Define api constants

### DIFF
--- a/constants/api/external.ts
+++ b/constants/api/external.ts
@@ -1,0 +1,42 @@
+const EXTERNAL_API = {
+  AUTH: {
+    LOGIN: '/auth/login',
+    CHANGE_PASSWORD: '/auth/password',
+  },
+  CARDS: {
+    ROOT: '/cards',
+    getDetail: (cardId: number) => `/cards/${cardId}`,
+  },
+  COLUMNS: {
+    ROOT: '/columns',
+    getDetail: (columnId: number) => `/columns/${columnId}`,
+    uploadCardImage: (columnId: number) => `/columns/${columnId}/card-image`,
+  },
+  COMMENTS: {
+    ROOT: '/comments',
+    getDetail: (commentId: number) => `/comments/${commentId}`,
+  },
+  DASHBOARDS: {
+    ROOT: '/dashboards',
+    getDetail: (dashboardId: number) => `/dashboards/${dashboardId}`,
+    invite: (dashboardId: number) => `/dashboards/${dashboardId}/invitations`,
+    cancelInvite: (dashboardId: number, invitationId: number) =>
+      `/dashboards/${dashboardId}/invitations/${invitationId}`,
+  },
+  INVITATIONS: {
+    ROOT: '/invitations',
+    acceptInvitation: (invitationId: number) => `/invitations/${invitationId}`,
+  },
+  MEMBERS: {
+    ROOT: '/members',
+    getDetail: (memberId: number) => `/members/${memberId}`,
+  },
+  USERS: {
+    SIGNUP: '/users',
+    GET_ME: '/users/me',
+    UPDATE_ME: '/users/me',
+    UPLOAD_PROFILE_IMAGE: '/users/me/image',
+  },
+};
+
+export default EXTERNAL_API;

--- a/constants/api/internal.ts
+++ b/constants/api/internal.ts
@@ -1,0 +1,7 @@
+const EXTERNAL_API = {
+  AUTH: {
+    LOGIN: '/api/auth/login',
+  },
+};
+
+export default EXTERNAL_API;


### PR DESCRIPTION
## #️⃣연관된 이슈, 작업

api 요청 주소 상수화

## 📝작업 내용

`/constants/api/`폴더에 api 주소 상수와 그걸 반환하는 함수를 만들었습니다.
internal, external은 내부, 외부 요청 주소를 구분해서 만든 파일입니다.

## 사용 예시

상수를 사용한 get 요청
```Typescript
import EXTERNAL_API from '@/constants/api/external';
import { api } from '@/lib/api';

const cardId = 123;
api.get(EXTERNAL_API.CARDS.getDetail(cardId)); // 카드 상세 조회
api.get(EXTERNAL_API.USERS.GET_ME); // 내 정보 조회
```

## 리뷰 요구사항

파일 위치, 변수 네이밍, 사용 방식 등 개선이 필요한 부분이 있다면 말씀해주세요.