### PR TITLE
Fix : Pagination error

### DIFF
--- a/app/(dashboard)/mydashboard/data.ts
+++ b/app/(dashboard)/mydashboard/data.ts
@@ -4,7 +4,7 @@ import { DashboardListResponse, Invitation, InvitationListResponse } from './typ
 
 export async function getMyDashboards(
   page: number = 1,
-  size: number = 6
+  size: number = 100
 ): Promise<DashboardListResponse> {
   const query = `?navigationMethod=pagination&page=${page}&size=${size}`;
   try {

--- a/components/Pagination/PaginationItems.tsx
+++ b/components/Pagination/PaginationItems.tsx
@@ -10,13 +10,17 @@ export default function PaginationItems<T>({
   currentPage,
 }: PaginationItemsProps<T>) {
   const currentItems = useMemo(() => {
+    const hasFixed = Boolean(renderFixedItem);
+
     if (currentPage === 1) {
       const count = renderFixedItem ? itemsPerPage - 1 : itemsPerPage;
       return data.slice(0, count);
     }
 
-    const start = (currentPage - 1) * itemsPerPage;
+    const baseStart = (currentPage - 1) * itemsPerPage;
+    const start = hasFixed ? baseStart - 1 : baseStart;
     const end = start + itemsPerPage;
+
     return data.slice(start, end);
   }, [data, currentPage, itemsPerPage, renderFixedItem]);
 

--- a/components/Pagination/PaginationItems.tsx
+++ b/components/Pagination/PaginationItems.tsx
@@ -45,12 +45,14 @@ export default function PaginationItems<T>({
 //       totalPages={totalPages}
 //       goToPrev={goToPrev}
 //       goToNext={goToNext}
+//       // ptional: showPageInfo, justify 등
 //     />
 
 //     <PaginationItems
 //       data={paginatedData}
 //       itemsPerPage={itemsPerPage}
 //       currentPage={currentPage}
+//       // optional: renderFixedItem, wrapperClassName 등
 //       renderItems={(items) => (
 //         <>
 //           {items.map((item) => (

--- a/components/Pagination/usePagination.ts
+++ b/components/Pagination/usePagination.ts
@@ -1,4 +1,4 @@
-import { useState, useMemo } from 'react';
+import { useState, useMemo, useEffect } from 'react';
 
 export function usePagination<T>(data: T[] = [], itemsPerPage: number) {
   const [currentPage, setCurrentPage] = useState(1);
@@ -14,6 +14,12 @@ export function usePagination<T>(data: T[] = [], itemsPerPage: number) {
   const goToNext = () => {
     setCurrentPage((prev) => Math.min(prev + 1, totalPages));
   };
+
+  useEffect(() => {
+    if (currentPage > totalPages) {
+      setCurrentPage(totalPages);
+    }
+  }, [totalPages, currentPage]);
 
   return {
     currentPage,

--- a/components/layout/SideNav/sideNavItems.tsx
+++ b/components/layout/SideNav/sideNavItems.tsx
@@ -11,10 +11,8 @@ interface SideNavItemsProps {
 }
 
 export default function SideNavItems({ selectedId, itemsPerPage }: SideNavItemsProps) {
-  const { dashboards, error } = useSideNavDashboards(itemsPerPage);
+  const { dashboards } = useSideNavDashboards(itemsPerPage);
   const { currentPage, totalPages, goToPrev, goToNext } = usePagination(dashboards, itemsPerPage);
-
-  if (error) return <div className="p-4 text-red-500">에러가 발생했습니다</div>;
 
   return (
     <>

--- a/components/layout/SideNav/useSideNavDashboards.tsx
+++ b/components/layout/SideNav/useSideNavDashboards.tsx
@@ -11,7 +11,7 @@ export function useSideNavDashboards(itemsPerPage: number) {
 
     async function fetchDashboards() {
       try {
-        const response = await getMyDashboards(1, itemsPerPage);
+        const response = await getMyDashboards();
         setDashboards(response.dashboards);
       } catch (err) {
         console.error('sidenav 목록 불러오기 에러:', err);


### PR DESCRIPTION
## #️⃣연관된 이슈, 작업

#108 

## 📝작업 내용

1. 대시보드 데이터를 불러올 때 size 값 조정: 6 -> 100
: pagination items와 controls가 제대로 렌더되지 않는 오류 해결

2. 현재 페이지(`currentPage`)가 총 페이지 수(`totalPages`)보다 커졌을 때, 현재 페이지를 자동으로 보정
```typescript
useEffect(() => {
  if (currentPage > totalPages) {
    setCurrentPage(totalPages);
  }
}, [totalPages, currentPage]);
```
- 브라우저 화면이 변경되어도 화면에 맞게 페이지네이션 적용

## 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> e.g. 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?