### PR TITLE
fix: 첫 번째 고정요소가 있을 때 2번째 페이지가 늦게 생기는 에러 수정

### DIFF
--- a/app/(dashboard)/mydashboard/MyDashboardSection.tsx
+++ b/app/(dashboard)/mydashboard/MyDashboardSection.tsx
@@ -2,6 +2,7 @@
 
 import Image from 'next/image';
 import { usePathname } from 'next/navigation';
+import { useEffect, useState } from 'react';
 import { useModal } from '@/hooks/useModal';
 import { usePagination } from '@/components/Pagination/usePagination';
 import Button from '@/components/common/Button';
@@ -11,11 +12,9 @@ import MyDashboardListItem from './MyDashboardListItem';
 import CreateDashboardModal from './CreateDashboardModal';
 import { getMyDashboards } from './data';
 import { Dashboard } from './types';
-import { useEffect, useState } from 'react';
 
 export default function MyDashboardSection() {
   const [myDashboards, setMyDashboards] = useState<Dashboard[]>([]);
-
   const pathname = usePathname();
   const { isOpen, open, close } = useModal();
   const selectedId = pathname?.split('/dashboard/')[1]?.split('/')[0];
@@ -29,7 +28,11 @@ export default function MyDashboardSection() {
 
   const itemsPerPage = 6;
 
-  const { currentPage, totalPages, goToPrev, goToNext } = usePagination(myDashboards, itemsPerPage);
+  const { currentPage, totalPages, goToPrev, goToNext } = usePagination(
+    myDashboards,
+    itemsPerPage,
+    true
+  );
 
   if (myDashboards.length === 0) {
     return (

--- a/components/Pagination/PaginationItems.tsx
+++ b/components/Pagination/PaginationItems.tsx
@@ -36,7 +36,7 @@ export default function PaginationItems<T>({
 
 // const itemsPerPage = ; // 페이지에 렌더할 아이템 수
 
-// const { currentPage, totalPages, goToPrev, goToNext } = usePagination(paginatedData, itemsPerPage);
+// const { currentPage, totalPages, goToPrev, goToNext } = usePagination(paginatedData, itemsPerPage, true); // 마지막 인자: 첫 번째 요소가 있을 경우 true, 없으면 false
 
 // return (
 //   <>
@@ -45,7 +45,7 @@ export default function PaginationItems<T>({
 //       totalPages={totalPages}
 //       goToPrev={goToPrev}
 //       goToNext={goToNext}
-//       // ptional: showPageInfo, justify 등
+//       // optional: showPageInfo, justify 등
 //     />
 
 //     <PaginationItems

--- a/components/Pagination/usePagination.ts
+++ b/components/Pagination/usePagination.ts
@@ -1,11 +1,21 @@
 import { useState, useMemo, useEffect } from 'react';
 
-export function usePagination<T>(data: T[] = [], itemsPerPage: number) {
+export function usePagination<T>(
+  data: T[] = [],
+  itemsPerPage: number,
+  hasFixedItem: boolean = false
+) {
   const [currentPage, setCurrentPage] = useState(1);
-  
+
   const totalPages = useMemo(() => {
+    if (hasFixedItem) {
+      const firstPageCount = itemsPerPage - 1;
+      const restCount = data.length - firstPageCount;
+      if (restCount <= 0) return 1;
+      return 1 + Math.ceil(restCount / itemsPerPage);
+    }
     return Math.max(1, Math.ceil(data.length / itemsPerPage));
-  }, [data.length, itemsPerPage]);
+  }, [data.length, itemsPerPage, hasFixedItem]);
 
   const goToPrev = () => {
     setCurrentPage((prev) => Math.max(prev - 1, 1));


### PR DESCRIPTION
첫 번째 고정요소가 있을 때 2번째 페이지가 늦게 생기는 에러 수정
(기존) `usePagination` 훅에서 고정 요소를 고려하지 않음
(수정) 고정 요소에 대한 예외처리