### PR TITLE
Refactor: Globals.css - default font color

### DIFF
--- a/app/(auth)/login/LoginForm.tsx
+++ b/app/(auth)/login/LoginForm.tsx
@@ -113,7 +113,7 @@ export default function LoginForm() {
         submitMessage="확인"
         onClose={() => setIsModalOpen(false)}
       >
-        <div className="text-black200 text-medium16 sm:text-medium20 flex w-full justify-center">
+        <div className="text-medium16 sm:text-medium20 flex w-full justify-center">
           {modalMessage}
         </div>
       </Modal>

--- a/app/(auth)/login/page.tsx
+++ b/app/(auth)/login/page.tsx
@@ -4,10 +4,10 @@ import LoginForm from '@/app/(auth)/login/LoginForm';
 export default async function Page() {
   return (
     <div className="flex flex-col items-center">
-      <h2 className="text-medium18 text-black200 mb-9">오늘도 만나서 반가워요!</h2>
+      <h2 className="text-medium18 mb-9">오늘도 만나서 반가워요!</h2>
       <LoginForm />
       <div className="mt-6">
-        <span className="text-black200 mr-2">회원이 아니신가요?</span>
+        <span className="mr-2">회원이 아니신가요?</span>
         <Link href={`/signup`} className="text-violet underline">
           회원가입하기
         </Link>

--- a/app/(auth)/signup/page.tsx
+++ b/app/(auth)/signup/page.tsx
@@ -3,11 +3,11 @@ import SignupForm from '@/components/SignupForm/components/SignupForm';
 
 export default function Signup() {
   return (
-    <div className="text-black200 flex flex-col items-center justify-center">
+    <div className="flex flex-col items-center justify-center">
       <span className="text-medium20 mb-[30px] max-sm:mb-9">첫 방문을 환영합니다!</span>
       <SignupForm />
       <div className="text-regular16 mt-6 flex items-center justify-center gap-2">
-        <span className="text-black200">이미 회원이신가요?</span>
+        <span>이미 회원이신가요?</span>
         <Link href={'/login'} className="text-violet underline">
           로그인하기
         </Link>

--- a/app/(dashboard)/dashboard/[dashboardId]/edit/DeleteDashboardModal.tsx
+++ b/app/(dashboard)/dashboard/[dashboardId]/edit/DeleteDashboardModal.tsx
@@ -33,7 +33,7 @@ export default function DeleteDashboardModal({
         cancelMessage="취소"
         onSubmit={handleClickDelete}
       >
-        <div className="text-black200 text-medium16 sm:text-medium20 flex w-full justify-center">
+        <div className="text-medium16 sm:text-medium20 flex w-full justify-center">
           대시보드가 삭제됩니다.
         </div>
       </Modal>

--- a/app/(dashboard)/mydashboard/InvitedSection.tsx
+++ b/app/(dashboard)/mydashboard/InvitedSection.tsx
@@ -62,7 +62,7 @@ export default function InvitedSection() {
   if (invitations.length === 0) {
     return (
       <div className="relative h-[390px] rounded-2xl bg-white px-10 py-6">
-        <h3 className="text-bold24 text-black200">초대받은 대시보드</h3>
+        <h3 className="text-bold24">초대받은 대시보드</h3>
         <div className="absolute top-1/2 left-1/2 flex -translate-x-1/2 -translate-y-1/2 flex-col items-center gap-[30px]">
           <div className="relative h-[75px] w-[87px]">
             <Image src="/invite.svg" fill alt="초대받은 대시보드" />
@@ -76,7 +76,7 @@ export default function InvitedSection() {
   return (
     <div className="flex flex-col gap-6 rounded-lg bg-white py-6">
       <div className="flex flex-col gap-8 px-10">
-        <h3 className="text-bold24 text-black200">초대받은 대시보드</h3>
+        <h3 className="text-bold24">초대받은 대시보드</h3>
         <Input
           placeholder="검색"
           value={keyword}

--- a/app/(dashboard)/mydashboard/MyDashboardListItem.tsx
+++ b/app/(dashboard)/mydashboard/MyDashboardListItem.tsx
@@ -33,7 +33,7 @@ export default function MyDashboardListItem({
         >
           <span
             className={clsx(
-              'text-black200 text-semi14 md:text-semi16 truncate',
+              'text-semi14 md:text-semi16 truncate',
               createdByMe ? 'max-w-[calc(100%-14px)]' : 'flex-1'
             )}
           >

--- a/app/(dashboard)/mydashboard/MyDashboardSection.tsx
+++ b/app/(dashboard)/mydashboard/MyDashboardSection.tsx
@@ -39,7 +39,7 @@ export default function MyDashboardSection() {
       <div className="w-full md:w-[247px] lg:w-[332px]">
         <div className="mb-[114px] flex flex-col gap-3">
           <Button variant="outline" size="dashboardCard" onClick={open} fullWidth>
-            <span className="text-black200 text-semi14 md:text-semi16">새로운 대시보드</span>
+            <span className="text-semi14 md:text-semi16">새로운 대시보드</span>
             <Image src="/icons/plus.svg" alt="추가" width={16} height={16} className="mr-2 ml-3" />
           </Button>
         </div>
@@ -56,7 +56,7 @@ export default function MyDashboardSection() {
         wrapperClassName="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3  grid-rows-2 gap-[13px]"
         renderFixedItem={() => (
           <Button variant="outline" size="dashboardCard" onClick={open}>
-            <span className="text-black200 text-semi14 md:text-semi16">새로운 대시보드</span>
+            <span className="text-semi14 md:text-semi16">새로운 대시보드</span>
             <Image src="/icons/plus.svg" alt="추가" width={16} height={16} className="mr-2 ml-3" />
           </Button>
         )}

--- a/app/(dashboard)/mypage/ChangePasswordForm.tsx
+++ b/app/(dashboard)/mypage/ChangePasswordForm.tsx
@@ -75,7 +75,7 @@ export default function ChangePasswordForm() {
   return (
     <>
       <form onSubmit={handleSubmit} className="rounded-2xl bg-white p-4 md:p-6">
-        <h2 className="text-bold20 text-black200 md:text-bold24">비밀번호 변경</h2>
+        <h2 className="text-bold20 md:text-bold24">비밀번호 변경</h2>
         <div className="my-6 flex flex-col gap-4">
           <FormField
             id="password"
@@ -132,7 +132,7 @@ export default function ChangePasswordForm() {
         submitMessage="확인"
         onClose={closeModal}
       >
-        <div className="text-black200 text-medium16 sm:text-medium20 flex w-full justify-center">
+        <div className="text-medium16 sm:text-medium20 flex w-full justify-center">
           {modalMessage}
         </div>
       </Modal>

--- a/app/(dashboard)/mypage/ProfileEditForm.tsx
+++ b/app/(dashboard)/mypage/ProfileEditForm.tsx
@@ -102,7 +102,7 @@ export default function ProfileEditForm() {
 
   return (
     <form onSubmit={handleSubmit} className="rounded-2xl bg-white p-4 md:p-6">
-      <h2 className="text-bold20 text-black200 md:text-bold24">프로필</h2>
+      <h2 className="text-bold20 md:text-bold24">프로필</h2>
       <div className="my-6 flex flex-col md:flex-row">
         <div className="mb-10 size-25 md:mr-10 md:mb-0 md:size-[180px] md:basis-[180px]">
           <UploadImage id="profileImageUrl" image={imagePreview} onChange={handleChangeImage} />
@@ -110,7 +110,7 @@ export default function ProfileEditForm() {
         <div className="w-full md:flex-1">
           <div className="mb-6 flex flex-col gap-4">
             <div className="flex flex-col gap-2">
-              <label className={`text-black200 text-regular14 md:text-regular16`}>이메일</label>
+              <label className={`text-regular14 md:text-regular16`}>이메일</label>
               <div className="text-gray400 text-regular16 border-gray300 hover:border-violet focus-within:border-violet truncate rounded-lg border-1 px-4 py-3 transition-colors">
                 {email}
               </div>

--- a/app/globals.css
+++ b/app/globals.css
@@ -3,6 +3,7 @@
 @layer {
   body {
     font-family: 'Pretendard', sans-serif;
+    color: var(--color-black200);
 
     button {
       cursor: pointer;

--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -11,7 +11,7 @@ export default function NotFound() {
             4<span className="text-violet-300">0</span>4
           </h1>
           <h2 className="text-violet -mt-10 mb-5 text-3xl font-bold">Not Found</h2>
-          <h3 className="text-black200 mb-7 text-5xl font-bold">
+          <h3 className="mb-7 text-5xl font-bold">
             페이지가 없거나 접근할 수 없어요
           </h3>
           <Link href="/">

--- a/components/BackLink/BackLink.tsx
+++ b/components/BackLink/BackLink.tsx
@@ -7,7 +7,7 @@ export default function BackLink({ backUrl }: { backUrl: string }) {
       <Link href={backUrl} className="flex w-fit items-center gap-2">
         <ArrowIcon width="18" height="18" className="hidden md:block" />
         <ArrowIcon width="16" height="16" className="block md:hidden" />
-        <span className="text-medium14 md:text-medium16 text-black200">돌아가기</span>
+        <span className="text-medium14 md:text-medium16">돌아가기</span>
       </Link>
     </>
   );

--- a/components/ColumnModal/ColumnManagementModal.tsx
+++ b/components/ColumnModal/ColumnManagementModal.tsx
@@ -92,7 +92,7 @@ export default function ColumnManagementModal({
       disabled={!hasColumnName}
     >
       <div className="flex w-full flex-col gap-6">
-        <h1 className="text-bold24 text-black200">새 컬럼 생성</h1>
+        <h1 className="text-bold24">새 컬럼 생성</h1>
         <FormField
           fieldType="input"
           label="이름"

--- a/components/Comment/Comment.tsx
+++ b/components/Comment/Comment.tsx
@@ -57,11 +57,11 @@ export default function Comment({ comment, getComments }: Comment) {
         <UserBadge size={34} profile={comment.author.profileImageUrl} />
         <div className="w-full">
           <div className="flex items-center gap-2">
-            <p className="text-semi14 text-black200">{comment.author.nickname}</p>
+            <p className="text-semi14">{comment.author.nickname}</p>
             <p className="text-regular12 text-gray400">{isUpdateAt}</p>
           </div>
           {!isEdit ? (
-            <p className="text-regular14 text-black200">{comment.content}</p>
+            <p className="text-regular14">{comment.content}</p>
           ) : (
             <div className="relative">
               <Textarea

--- a/components/Dashboard/AddColumnBtn.tsx
+++ b/components/Dashboard/AddColumnBtn.tsx
@@ -12,7 +12,7 @@ export default function AddColumnBtn() {
     <>
       <ColumnManagementModal isOpen={isOpen} onClose={close} option="create" />
       <Button size="addColumn" variant="outline" onClick={open}>
-        <div className="text-bold18 text-black200 flex gap-3">
+        <div className="text-bold18 flex gap-3">
           <span className="hidden sm:block">새로운 칼럼 추가하기</span>
           <Plus />
         </div>

--- a/components/DeleteColumnModal/DeleteColumnModal.tsx
+++ b/components/DeleteColumnModal/DeleteColumnModal.tsx
@@ -24,7 +24,7 @@ export default function DeleteColumnModal({ isOpen, onClose, columnId }: DeleteC
         cancelMessage="취소"
         onSubmit={handelColumnDelete}
       >
-        <div className="text-black200 text-medium16 sm:text-medium20 flex w-full justify-center">
+        <div className="text-medium16 sm:text-medium20 flex w-full justify-center">
           컬럼의 모든 카드가 삭제됩니다.
         </div>
       </Modal>

--- a/components/Pagination/PaginationControls.tsx
+++ b/components/Pagination/PaginationControls.tsx
@@ -30,7 +30,7 @@ export default function PaginationControls({
   return (
     <div className={`flex items-center gap-4 ${justifyClass}`}>
       {showPageInfo && (
-        <span className="text-black200 text-regular14">
+        <span className="text-regular14">
           {totalPages} 페이지 중 {currentPage}
         </span>
       )}

--- a/components/SignupForm/components/CheckBox.tsx
+++ b/components/SignupForm/components/CheckBox.tsx
@@ -22,7 +22,7 @@ export default function CheckBox({ isChecked, handleIsChecked }: CheckBoxProps) 
         alt="check"
         className="absolute hidden peer-checked:block"
       />
-      <span className="text-regular16 text-black200 select-none">이용약관에 동의합니다.</span>
+      <span className="text-regular16 select-none">이용약관에 동의합니다.</span>
     </label>
   );
 }

--- a/components/SignupForm/components/SignupForm.tsx
+++ b/components/SignupForm/components/SignupForm.tsx
@@ -55,7 +55,7 @@ export default function SignupForm() {
         submitMessage="확인"
         onClose={onClose}
       >
-        <div className="text-black200 text-medium16 sm:text-medium20 flex w-full justify-center">
+        <div className="text-medium16 sm:text-medium20 flex w-full justify-center">
           {state?.message}
         </div>
       </Modal>

--- a/components/ToDoFormModal/DueDate.tsx
+++ b/components/ToDoFormModal/DueDate.tsx
@@ -14,7 +14,7 @@ interface DueDateProps {
 export default function DueDate({ onDueDateChange, dueDate }: DueDateProps) {
   return (
     <div className="flex flex-col">
-      <label className="text-medium18 text-black200 mb-2 flex items-center">마감일</label>
+      <label className="text-medium18 mb-2 flex items-center">마감일</label>
       <DatePicker
         locale="ko"
         className="w-full border-none outline-none"

--- a/components/ToDoFormModal/TagInput.tsx
+++ b/components/ToDoFormModal/TagInput.tsx
@@ -53,12 +53,12 @@ export default function TagInput({
 
   return (
     <div className="flex flex-col gap-2">
-      <label className="text-medium18 text-black200 flex items-center">
+      <label className="text-medium18 flex items-center">
         태그
         <span className="text-gray400 text-regular12"> (더블 클릭 시 해당 태그는 삭제됩니다)</span>
       </label>
       <div
-        className={`text-black200 border-gray300 flex h-[52px] w-full items-center gap-2 rounded-lg border px-4 py-3 ${isEqual ? 'border-red hover:border-red focus-within:border-red' : 'hover:border-violet focus-within:border-violet'}`}
+        className={`border-gray300 flex h-[52px] w-full items-center gap-2 rounded-lg border px-4 py-3 ${isEqual ? 'border-red hover:border-red focus-within:border-red' : 'hover:border-violet focus-within:border-violet'}`}
       >
         {tags.map((t) => (
           <Tag

--- a/components/ToDoFormModal/ToDoFormModal.tsx
+++ b/components/ToDoFormModal/ToDoFormModal.tsx
@@ -120,11 +120,11 @@ export default function ToDoFormModal({
       disabled={!isFormComplete}
     >
       <div className="flex w-full flex-col gap-8">
-        <h1 className="text-bold24 text-black200">할 일 {createOrUpdate}</h1>
+        <h1 className="text-bold24">할 일 {createOrUpdate}</h1>
         <div className="flex flex-col gap-8 md:flex-row">
           {card?.id && (
             <div className="flex flex-1 flex-col gap-2">
-              <label className="text-black200 text-medium18">상태</label>
+              <label className="text-medium18">상태</label>
               <SelectionDropdown
                 options={columnList}
                 onSelect={(option: DropdownItem) => {
@@ -135,7 +135,7 @@ export default function ToDoFormModal({
             </div>
           )}
           <div className="flex flex-1 flex-col gap-2">
-            <label className="text-black200 text-medium18">담당자</label>
+            <label className="text-medium18">담당자</label>
             <SearchableDropdown
               options={memberList}
               onSelect={(option: DropdownItem) => {
@@ -170,7 +170,7 @@ export default function ToDoFormModal({
         />
         <TagInput writtenTags={card?.tags} onChange={(tags: string[]) => handleTagsChange(tags)} />
         <div className="flex flex-col gap-[5px]">
-          <label className="text-black200 text-medium18">이미지</label>
+          <label className="text-medium18">이미지</label>
           <div className="relative h-[58px] w-[58px] rounded-lg md:h-[76px] md:w-[76px]">
             <UploadImage
               image={image === DEFAULT_CARD_IMAGE ? '' : image}

--- a/components/common/Button/style.ts
+++ b/components/common/Button/style.ts
@@ -15,7 +15,7 @@ const sizes = {
 
 const variants = {
   solid: 'bg-violet text-white disabled:bg-gray400',
-  outline: 'bg-white border border-gray300 text-gray500',
+  outline: 'bg-white border border-gray300',
   ghost: 'bg-white border border-gray300 text-violet',
 };
 

--- a/components/common/Input/index.tsx
+++ b/components/common/Input/index.tsx
@@ -29,7 +29,7 @@ const Input = ({
     >
       {leftIcon && leftIcon}
       <input
-        className={`w-full border-none text-[var(--color-black200)] outline-none placeholder:text-[var(--color-gray400)] ${getFontSize(size)} ${customInputClass}`}
+        className={`w-full border-none outline-none placeholder:text-[var(--color-gray400)] ${getFontSize(size)} ${customInputClass}`}
         ref={ref}
         disabled={disabled}
         {...props}

--- a/components/common/Modal/index.tsx
+++ b/components/common/Modal/index.tsx
@@ -66,6 +66,7 @@ export default function Modal({
               size={twoButton ? 'modal' : 'modalAlert'}
               onClick={onClose}
               fullWidth
+              className='text-gray500'
             >
               {cancelMessage}
             </Button>

--- a/components/common/Textarea/index.tsx
+++ b/components/common/Textarea/index.tsx
@@ -23,7 +23,7 @@ const Textarea = ({
       className={`${getBorderClasses(disabled, isValid)} rounded-lg border px-4 py-3 ${customBorderClass}`}
     >
       <textarea
-        className={`${getFontSize(size)} text-black200 w-full resize-none border-none outline-none placeholder:${getFontSize(size)} placeholder:text-gray400 ${customTextareaClass}`}
+        className={`${getFontSize(size)} w-full resize-none border-none outline-none placeholder:${getFontSize(size)} placeholder:text-gray400 ${customTextareaClass}`}
         rows={rows}
         {...props}
       />

--- a/components/compound/form/FormField.tsx
+++ b/components/compound/form/FormField.tsx
@@ -20,7 +20,7 @@ const FormField = (props: FormFieldProps) => {
     <div className="flex flex-col gap-2">
       <label
         htmlFor={id}
-        className={`text-medium18 text-black200 flex items-center gap-[2px] ${customLabelClass}`}
+        className={`text-medium18 flex items-center gap-[2px] ${customLabelClass}`}
       >
         {label}
         {required && <span className="text-violet">*</span>}

--- a/components/compound/modal/ColumnDetailModal.tsx
+++ b/components/compound/modal/ColumnDetailModal.tsx
@@ -159,12 +159,12 @@ const ColumnDetailModal = ({
           <h2 className="text-semi12">담당자</h2>
           <div className="flex items-center gap-2">
             {renderProfileImage(cardData.assignee.profileImageUrl ?? '')}
-            <p className="text-regular12 text-black200">{cardData.assignee.nickname}</p>
+            <p className="text-regular12">{cardData.assignee.nickname}</p>
           </div>
         </div>
         <div className="flex w-[109px] flex-col gap-2 md:gap-[6px]">
           <h3 className="text-semi12">마감일</h3>
-          <p className="text-regular12 text-black200">{formatDate(cardData.dueDate, true)}</p>
+          <p className="text-regular12">{formatDate(cardData.dueDate, true)}</p>
         </div>
       </div>
       <div className="flex flex-col gap-4">
@@ -190,7 +190,7 @@ const ColumnDetailModal = ({
   const renderCommentInput = () => (
     <div className="mt-6 flex flex-col">
       <div className="relative flex flex-col gap-1">
-        <label htmlFor="comment" className="text-medium16 text-black200">
+        <label htmlFor="comment" className="text-medium16">
           댓글
         </label>
         <Textarea
@@ -231,7 +231,7 @@ const ColumnDetailModal = ({
   //       )}
   //     </div>
   //   ) : (
-  //     <p className="text-regular14 text-black200 flex items-center justify-center">
+  //     <p className="text-regular14 flex items-center justify-center">
   //       마지막 댓글입니다.
   //     </p>
   //   );


### PR DESCRIPTION
## #️⃣연관된 이슈, 작업

> #1 
> #34 

## 📝작업 내용

> Default font color 설정
- `globals.css`에 `color` 정의: `black200`
- 문서 내 `black200` 스타일 코드 삭제

> Button 공통 컴포넌트 (outline)
- 디자인 가이드에서 outline button이 `Modal`에서 사용될 때만 `gray500`으로 적용되고, 그 외에는 문서의 기본 폰트 컬러가 적용됨을 확인
-> `variant="outline"`일 때, 폰트 컬러 `gray500` 삭제 (필요한 곳에서 개별 성정)
- `Modal`의 취소 버튼에 `gray500` 컬러를 별도로 설정하여 수정했습니다! (@heewls )

## 💬리뷰 요구사항(선택)

> 혹시 수정된 부분에서 문제가 발생할 경우 말씀해주세요!
